### PR TITLE
Fixed error from `set -u`: 'action: unbound variable'

### DIFF
--- a/rabbitmq-smoke-tests-dev
+++ b/rabbitmq-smoke-tests-dev
@@ -216,7 +216,7 @@ fi
 bosh_target_check
 bosh_cli_check
 
-declare -a args
+declare -a args=(args)
 if (( ${#@} ))
 then args=($(echo "${@}"))
 fi


### PR DESCRIPTION
#### Error

```
$ ./rabbitmq-smoke-tests-dev prepare
Current target is https://192.168.50.4:25555 (Bosh Lite Director)
./rabbitmq-smoke-tests-dev: line 225: args: unbound variable
```
