### PR TITLE
test password is now configurable

### DIFF
--- a/jobs/smoke-tests/spec
+++ b/jobs/smoke-tests/spec
@@ -31,3 +31,6 @@ properties:
   rabbitmq.skip_ssl:
     description: "true if the tests should skip ssl validation when creating a RabbitMQ agent. false otherwise"
     default: false
+  rabbitmq.password:
+    description: "the password used for testing the rabbitmq instances"
+    default: "meow"

--- a/jobs/smoke-tests/templates/config/smoke-tests.json
+++ b/jobs/smoke-tests/templates/config/smoke-tests.json
@@ -6,6 +6,7 @@
   "service_name":   "<%= p('rabbitmq.service_name') %>",
   "plan_names":		<%= p('rabbitmq.plan_names') %>,
   "rabbitmq_skip_ssl": <%= p('rabbitmq.skip_ssl') %>,
+  "test_password": "<%= p('rabbitmq.password') %>",
   "skip_ssl_validation": true,
   "create_permissive_security_group": true
 }

--- a/templates/infrastructure/warden.yml
+++ b/templates/infrastructure/warden.yml
@@ -14,7 +14,7 @@ update:
 
 jobs:
   - name: smoke-tests
-    instances: 2
+    instances: 1
     networks:
       - name: smoke-tests
         static_ips: ~

--- a/templates/jobs.yml
+++ b/templates/jobs.yml
@@ -12,7 +12,7 @@ jobs:
     templates:
     - name: smoke-tests
       release: rabbitmq-smoke-tests
-    instances: 0
+    instances: 1
     resource_pool: small_z1
     update:
       canaries: 10
@@ -26,3 +26,4 @@ jobs:
         service_name: p-rabbitmq
         plan_names: '[ "standard" ]'
         skip_ssl: (( merge ))
+        password: anything_but_meow


### PR DESCRIPTION
The password used for the rabbitmq user is now configurable in the manifest.
